### PR TITLE
Fix invalid JSON in `contributing.md`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -56,7 +56,7 @@ The following code sample is a minimum viable `device.json`:
 {
     "title": "My Awesome Device",
     "type": "notebook",
-    "screen": 
+    "screen": {
         "horizontal": {
             "width": 1024, 
             "height": 968
@@ -65,7 +65,8 @@ The following code sample is a minimum viable `device.json`:
         "vertical": {
             "width": 968, 
             "height": 1024
-        },
+        }
+    },
     "user-agent": "Latest UA for given device",
     "show-by-default": false
 }


### PR DESCRIPTION
The sample `device.json` file in `contributing.md` had a syntax error, there were no curly braces for the `screen` field.
