### PR TITLE
Adding 550 and correcting UA for 950

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -498,7 +498,7 @@
                     "width": 533,
                     "height": 320
                 },
-                "device-pixel-ratio": 1.4,
+                "device-pixel-ratio": 1.5,
                 "vertical": {
                     "width": 320,
                     "height": 533

--- a/devices.json
+++ b/devices.json
@@ -544,7 +544,7 @@
                 "touch",
                 "mobile"
             ],
-            "user-agent": "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10586",
+            "user-agent": "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263",
             "type": "phone",
             "modes": [
                 {

--- a/devices.json
+++ b/devices.json
@@ -531,13 +531,13 @@
             "title": "Microsoft Lumia 550",
             "screen": {
                 "horizontal": {
-                    "width": 1280,
-                    "height": 720
+                    "width": 640,
+                    "height": 360
                 },
                 "device-pixel-ratio": 2,
                 "vertical": {
-                    "width": 1280,
-                    "height": 720
+                    "width": 640,
+                    "height": 360
                 }
             },
             "capabilities": [
@@ -567,13 +567,13 @@
             "title": "Microsoft Lumia 950",
             "screen": {
                 "horizontal": {
-                    "width": 2560,
-                    "height": 1440
+                    "width": 640,
+                    "height": 360
                 },
                 "device-pixel-ratio": 4,
                 "vertical": {
-                    "width": 1440,
-                    "height": 2560
+                    "width": 360,
+                    "height": 640
                 }
             },
             "capabilities": [

--- a/devices.json
+++ b/devices.json
@@ -498,7 +498,7 @@
                     "width": 533,
                     "height": 320
                 },
-                "device-pixel-ratio": 1.5,
+                "device-pixel-ratio": 1.4,
                 "vertical": {
                     "width": 320,
                     "height": 533
@@ -528,16 +528,52 @@
         "type": "emulated-device",
         "device": {
             "show-by-default": false,
+            "title": "Microsoft Lumia 550",
+            "screen": {
+                "horizontal": {
+                    "width": 1280,
+                    "height": 720
+                },
+                "device-pixel-ratio": 2,
+                "vertical": {
+                    "width": 1280,
+                    "height": 720
+                }
+            },
+            "capabilities": [
+                "touch",
+                "mobile"
+            ],
+            "user-agent": "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/14.14263",
+            "type": "phone",
+            "modes": [
+                {
+                    "title": "default",
+                    "orientation": "vertical",
+                    "insets": { "left": 0, "top": 0, "right": 0, "bottom": 0 }
+                },
+                {
+                    "title": "default",
+                    "orientation": "horizontal",
+                    "insets": { "left": 0, "top": 0, "right": 0, "bottom": 0 }
+                }
+            ]
+        }
+    },
+    {
+        "type": "emulated-device",
+        "device": {
+            "show-by-default": false,
             "title": "Microsoft Lumia 950",
             "screen": {
                 "horizontal": {
-                    "width": 640,
-                    "height": 360 
+                    "width": 2560,
+                    "height": 1440
                 },
                 "device-pixel-ratio": 4,
                 "vertical": {
-                    "width": 360,
-                    "height": 640
+                    "width": 1440,
+                    "height": 2560
                 }
             },
             "capabilities": [

--- a/devices.json
+++ b/devices.json
@@ -544,7 +544,7 @@
                 "touch",
                 "mobile"
             ],
-            "user-agent": "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10587",
+            "user-agent": "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10586",
             "type": "phone",
             "modes": [
                 {


### PR DESCRIPTION
1. Adding a Microsoft 550 device so that there is both the latest high end and budget Win10 device is in the list. Leaving in the 520 as it is the most widely deployed device (source: http://blog.adduplex.com/2016/02/adduplex-windows-phone-device-statistics-report-for-february-2016.html) but hopefully that can go with time :).
2. Updating the UA string for the 950 to reflect what it is at retail.
3. Also removing some trailing whitespace
